### PR TITLE
Support Accession downloads in V2.3.1

### DIFF
--- a/backend/controllers/download_accessions_controller.rb
+++ b/backend/controllers/download_accessions_controller.rb
@@ -25,7 +25,7 @@ class ArchivesSpaceService < Sinatra::Base
 
   def content
     params[:filter_term] ||= []
-    params[:filter_term] << {'primary_type' => 'accession'}.to_json
+    params[:type] = 'accession'
     params[:page] = 1
     params[:page_size] = 100
 
@@ -34,7 +34,6 @@ class ArchivesSpaceService < Sinatra::Base
 
       while true
         resp = Search.search(params, params[:repo_id])
-
         resp['results'].each do |r|
           j = ASUtils.json_parse(r['json'])
           ud = j['user_defined'] || {}

--- a/backend/controllers/download_accessions_controller.rb
+++ b/backend/controllers/download_accessions_controller.rb
@@ -39,6 +39,7 @@ class ArchivesSpaceService < Sinatra::Base
           j = ASUtils.json_parse(r['json'])
           ud = j['user_defined'] || {}
           cm = j['collection_management'] || {}
+          j['extents'] = {} unless j['extents']
           extent1 = j['extents'][0] || {}
           extent2 = j['extents'][1] || {}
           csv << [
@@ -51,7 +52,7 @@ class ArchivesSpaceService < Sinatra::Base
                   j['access_restrictions_note'],
                   j['disposition'],
                   j['acquisition_type'],
-                  format_dates(j['dates']),
+                  format_dates(j['dates'] || {}),
                   extent1['number'],
                   extent1['extent_type'],
                   extent1['container_summary'],
@@ -62,7 +63,7 @@ class ArchivesSpaceService < Sinatra::Base
                   extent2['container_summary'],
                   extent2['physical_details'],
                   extent2['dimensions'],
-                  format_subjects(r['subjects']),
+                  format_subjects(r['subjects'] || []),
                   ud['text_2'],
                   ud['text_3'],
                   ud['text_4'],

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -1,4 +1,4 @@
-class CommonIndexer
+class IndexerCommon
 
   add_indexer_initialize_hook do |indexer|
 


### PR DESCRIPTION
The class name for the indexer has changed.

The search functionality has apparently changed; at first we thought that we had accession records with some missing keys (hence the belt-and-suspenders of doing things like format_subjects(r['subjects'] || []) ), but realized that changing the search parameters yielded the correct results (prior to the change, we were getting all the agent records as well!)